### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/MultiStorage.js
+++ b/MultiStorage.js
@@ -5,7 +5,7 @@ let printf = require('util').format;
 let Callback = require('node-callback');
 let async = require('async');
 let URL = require('url');
-let uuid = require('node-uuid');
+let uuid = require('uuid');
 let PassThrough = require('stream').PassThrough;
 
 let hrBytes = function(bytes, decimals) {

--- a/package.json
+++ b/package.json
@@ -45,8 +45,8 @@
   "dependencies": {
     "async": "^2.0.0-rc.6",
     "node-callback": "^1.0.2",
-    "node-uuid": "^1.4.7",
-    "underscore": "^1.8.3"
+    "underscore": "^1.8.3",
+    "uuid": "^3.0.0"
   },
   "description": "Provides access to file system operations independent from the storage system used",
   "devDependencies": {


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.